### PR TITLE
 Update Plaid bank coverage;

### DIFF
--- a/data/account-providers/abn-amro.json
+++ b/data/account-providers/abn-amro.json
@@ -131,6 +131,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "klarna",

--- a/data/account-providers/acorns.json
+++ b/data/account-providers/acorns.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/activobank-pt.json
+++ b/data/account-providers/activobank-pt.json
@@ -297,6 +297,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "budget-insight",
     "salt-edge"

--- a/data/account-providers/aib.json
+++ b/data/account-providers/aib.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "AIBKGB2LXXX"

--- a/data/account-providers/albert.json
+++ b/data/account-providers/albert.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/aliorbank-pl.json
+++ b/data/account-providers/aliorbank-pl.json
@@ -68,6 +68,7 @@
     "POLISHAPI"
   ],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "enablebanking",
     "fintecture",

--- a/data/account-providers/ally.json
+++ b/data/account-providers/ally.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/amerisbank.json
+++ b/data/account-providers/amerisbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/applebank.json
+++ b/data/account-providers/applebank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/arbejdernes-landsbank.json
+++ b/data/account-providers/arbejdernes-landsbank.json
@@ -1,7 +1,11 @@
 {
   "id": "arbejdernes-landsbank",
-  "type": ["account"],
-  "bankType": ["retail"],
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "retail"
+  ],
   "name": "Arbejdernes Landsbank",
   "legalName": "A/S Arbejdernes Landsbank",
   "ipoStatus": "private",
@@ -9,14 +13,14 @@
   "icon": "https://res.cloudinary.com/banq/image/upload/v1553180025/radar/icons/Arbejdernes_Landsbank.jpg",
   "websiteUrl": "https://www.al-bank.dk/",
   "ownership": [
-    { 
+    {
       "shareholderName": "Danske Metal",
       "shareholderIconUrl": "https://res.cloudinary.com/banq/image/upload/v1553180208/radar/icons/DanskMetal.png",
       "providerId": "danske-metal",
       "percentage": 12.7,
       "sourceUrl": "https://www.al-bank.dk/media/131314/al_annual_report_2018.pdf"
     },
-    { 
+    {
       "shareholderName": "Fagligt Fælles Forbund",
       "shareholderIconUrl": "https://res.cloudinary.com/banq/image/upload/v1553180291/radar/icons/Fagligt_F%C3%A6lles_Forbund.jpg",
       "providerId": "fagligt-faelles-Forbund",
@@ -26,9 +30,11 @@
   ],
   "stateOwned": false,
   "countryHQ": "DK",
-  "countries": ["DK"],
+  "countries": [
+    "DK"
+  ],
   "compliance": [
-    { 
+    {
       "regulation": "PSD2",
       "status": "inProgress"
     }
@@ -41,7 +47,9 @@
     {
       "label": "BG Account Information Service API (AIS)",
       "type": "accountInformation",
-      "categories": ["accounts"],
+      "categories": [
+        "accounts"
+      ],
       "description": "The AIS API implements the Account Information Service parts of the PSD2 specification, and provides the following services to authorized TPPs: Accounts overview, Account details, Account balances, Account transactions",
       "documentationUrl": null,
       "apiReferenceUrl": "https://apiportal.prod.bec.dk/openbanking/sandbox/node/265",
@@ -51,7 +59,9 @@
     {
       "label": "BG Payment Initiation API (PIS)",
       "type": "paymentInitiation",
-      "categories": ["payments"],
+      "categories": [
+        "payments"
+      ],
       "description": "The PIS API implements the Payment Initiation Service parts of the PSD2 specification, and provides the following services to authorized TPPs: Initiation and update of a payment request, Status information of a payment",
       "documentationUrl": null,
       "apiReferenceUrl": "https://apiportal.prod.bec.dk/openbanking/sandbox/node/268",
@@ -59,7 +69,9 @@
       "stage": "sandbox"
     }
   ],
-  "apiStandards": ["BERLIN"],
+  "apiStandards": [
+    "BERLIN"
+  ],
   "webApplication": true,
   "mobileApps": [
     {
@@ -84,5 +96,8 @@
   "crunchbase": "arbejdernes-landsbank",
   "github": "DanskeBank",
   "fca": null,
-  "articles": []
+  "articles": [],
+  "apiAggregators": [
+    "plaid"
+  ]
 }

--- a/data/account-providers/arvest-bank.json
+++ b/data/account-providers/arvest-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/askzeta.json
+++ b/data/account-providers/askzeta.json
@@ -34,7 +34,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/asn-bank.json
+++ b/data/account-providers/asn-bank.json
@@ -43,6 +43,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.devolksbank.nl/admin/app/api-catalog",
   "apiAggregators": [
+    "plaid",
     "bankingsdk",
     "klarna",
     "ibanity",

--- a/data/account-providers/aspiration.json
+++ b/data/account-providers/aspiration.json
@@ -30,7 +30,9 @@
   "apiReferenceUrl": "",
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],
@@ -63,7 +65,7 @@
           "date": "2019-06-21",
           "verified": true
         }
-      },      
+      },
       {
         "amount": "1000000",
         "type": "claim",

--- a/data/account-providers/avidiabank.json
+++ b/data/account-providers/avidiabank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/axosbank.json
+++ b/data/account-providers/axosbank.json
@@ -27,7 +27,9 @@
   "openBankProjectUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "webApplication": true,

--- a/data/account-providers/banca-carige.json
+++ b/data/account-providers/banca-carige.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CRGEITGG201"

--- a/data/account-providers/banca-fideuram.json
+++ b/data/account-providers/banca-fideuram.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "FIBKITMM"

--- a/data/account-providers/banca-mediolanum.json
+++ b/data/account-providers/banca-mediolanum.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "MEDBITMM"

--- a/data/account-providers/banca-widiba.json
+++ b/data/account-providers/banca-widiba.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "WIDIITMMXXX"

--- a/data/account-providers/bancaakros-it.json
+++ b/data/account-providers/bancaakros-it.json
@@ -45,6 +45,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "ibanity",
     "salt-edge"
   ],

--- a/data/account-providers/banco-bpm.json
+++ b/data/account-providers/banco-bpm.json
@@ -37,6 +37,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://cbiglobeopenbankingapiportal.nexi.it",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "equensworldline",
     "truelayer",

--- a/data/account-providers/bank-of-ireland.json
+++ b/data/account-providers/bank-of-ireland.json
@@ -95,6 +95,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "token",
     "yolt",
     "openwrks",

--- a/data/account-providers/bank-of-scotland.json
+++ b/data/account-providers/bank-of-scotland.json
@@ -1,7 +1,12 @@
 {
   "id": "bank-of-scotland",
-  "type": ["account"],
-  "bankType": ["retail","corporate"],
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "retail",
+    "corporate"
+  ],
   "name": "Bank of Scotland",
   "legalName": "Bank of Scotland plc",
   "ipoStatus": "private",
@@ -9,19 +14,21 @@
   "icon": "https://res.cloudinary.com/banq/image/upload/v1552648073/radar/icons/UfYosl_o_400x400.jpg",
   "websiteUrl": "https://www.bankofscotland.co.uk/",
   "ownership": [
-    { 
+    {
       "shareholderName": "Lloyds Banking Group",
       "shareholderIconUrl": "https://res.cloudinary.com/banq/image/upload/v1552296073/radar/icons/Lloyds_Banking_Group.jpg",
       "providerId": "lloyds",
-      "percentage": 100.0,
+      "percentage": 100,
       "sourceUrl": "https://www.lloydsbankinggroup.com/Our-Group/our-heritage/our-history/bank-of-scotland/bank-of-scotland/"
     }
   ],
   "stateOwned": false,
   "countryHQ": "GB",
-  "countries": ["GB"],
+  "countries": [
+    "GB"
+  ],
   "compliance": [
-    { 
+    {
       "regulation": "OB",
       "status": "inProgress"
     }
@@ -34,7 +41,9 @@
     {
       "label": "/branches",
       "type": "branchLocator",
-      "categories": ["locators"],
+      "categories": [
+        "locators"
+      ],
       "description": "Gets a list of all Branch objects.",
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-branches-2.2",
@@ -44,7 +53,9 @@
     {
       "label": "/personal-current-accounts",
       "type": "accountInformation",
-      "categories": ["accounts"],
+      "categories": [
+        "accounts"
+      ],
       "description": "Gets a list of all Personal Current Account objects.",
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-personal-current-accounts-2.2",
@@ -55,7 +66,9 @@
       "label": "/atms",
       "type": "atmLocator",
       "description": "Gets a list of all ATM objects.",
-      "categories": ["locators"],
+      "categories": [
+        "locators"
+      ],
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-atms-2.2",
       "premium": false,
@@ -64,7 +77,9 @@
     {
       "label": "/business-current-accounts",
       "type": "accountInformation",
-      "categories": ["accounts"],
+      "categories": [
+        "accounts"
+      ],
       "description": "Gets a list of all Branch Current Account objects.",
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-business-current-accounts-2.2",
@@ -75,7 +90,9 @@
       "label": "/unsecured-sme-loans",
       "type": "productFinder",
       "description": "Gets a list of all Unsercured SME Lending objects.",
-      "categories": ["loans"],
+      "categories": [
+        "loans"
+      ],
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-unsecured-sme-loans-2.2",
       "premium": false,
@@ -85,7 +102,9 @@
       "label": "/commercial-credit-cards",
       "type": "productFinder",
       "description": "Gets a list of all Commerical Credit Card objects.",
-      "categories": ["accounts"],
+      "categories": [
+        "accounts"
+      ],
       "documentationUrl": null,
       "apiReferenceUrl": "https://developer.bankofscotland.co.uk/opendata-v2.2#get-commercial-credit-cards-2.2",
       "premium": false,
@@ -94,6 +113,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "truelayer",
     "klarna",

--- a/data/account-providers/bank-pekao.json
+++ b/data/account-providers/bank-pekao.json
@@ -50,6 +50,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.pekao.com.pl/api/",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "banqup",
     "enablebanking",

--- a/data/account-providers/bankgreenwood.json
+++ b/data/account-providers/bankgreenwood.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/bankmobile.json
+++ b/data/account-providers/bankmobile.json
@@ -40,7 +40,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/bankofamerica.json
+++ b/data/account-providers/bankofamerica.json
@@ -28,6 +28,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.bankofamerica.com",
   "apiAggregators": [
+    "plaid",
     "truelayer"
   ],
   "apiProducts": [

--- a/data/account-providers/bankofthewest.json
+++ b/data/account-providers/bankofthewest.json
@@ -39,7 +39,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/bankprov.json
+++ b/data/account-providers/bankprov.json
@@ -44,7 +44,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/bankwithfair.json
+++ b/data/account-providers/bankwithfair.json
@@ -36,7 +36,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/banquepopulaire-fr.json
+++ b/data/account-providers/banquepopulaire-fr.json
@@ -144,6 +144,7 @@
   ],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "bridgeapi-io",

--- a/data/account-providers/barclaycard.json
+++ b/data/account-providers/barclaycard.json
@@ -35,6 +35,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BARCDEHAXXX"

--- a/data/account-providers/berkshirebank.json
+++ b/data/account-providers/berkshirebank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/berliner-sparkasse.json
+++ b/data/account-providers/berliner-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BELADEBEXXX"

--- a/data/account-providers/betenth.json
+++ b/data/account-providers/betenth.json
@@ -32,7 +32,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/blueridgebank.json
+++ b/data/account-providers/blueridgebank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/bluevine.json
+++ b/data/account-providers/bluevine.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/bnp-italy.json
+++ b/data/account-providers/bnp-italy.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://bnl.it/it/Individui-e-Famiglie/Internet-e-Mobile/Navigare-in-sicurezza/PSD2",
   "apiAggregators": [
+    "plaid",
     "budget-insight",
     "klarna"
   ],

--- a/data/account-providers/bper-banca.json
+++ b/data/account-providers/bper-banca.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://cbiglobeopenbankingapiportal.nexi.it",
   "apiAggregators": [
+    "plaid",
     "equensworldline",
     "salt-edge"
   ],

--- a/data/account-providers/bpp.json
+++ b/data/account-providers/bpp.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BPPUIT33XXX"

--- a/data/account-providers/branchapp.json
+++ b/data/account-providers/branchapp.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/brex.json
+++ b/data/account-providers/brex.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [],
   "webApplication": true,

--- a/data/account-providers/caisse-epargne.json
+++ b/data/account-providers/caisse-epargne.json
@@ -110,6 +110,7 @@
   ],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "equensworldline",
     "truelayer"
   ],

--- a/data/account-providers/cashplus.json
+++ b/data/account-providers/cashplus.json
@@ -36,6 +36,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://apisandbox.mycashplus.co.uk/swagger/ui/index#!/Root32Infrastructure",
   "apiAggregators": [
+    "plaid",
     "openwrks",
     "moneyhub-enterprise"
   ],

--- a/data/account-providers/cassa-di-risparmio-di-bolzano.json
+++ b/data/account-providers/cassa-di-risparmio-di-bolzano.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CRBZIT2BXXX"

--- a/data/account-providers/cater-allen.json
+++ b/data/account-providers/cater-allen.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CATEGB21XXX"

--- a/data/account-providers/ccamm.json
+++ b/data/account-providers/ccamm.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CDOTPTP1XXX"

--- a/data/account-providers/chebanca.json
+++ b/data/account-providers/chebanca.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.chebanca.it/",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "salt-edge"
   ],

--- a/data/account-providers/chime.json
+++ b/data/account-providers/chime.json
@@ -35,7 +35,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/choice-bank.json
+++ b/data/account-providers/choice-bank.json
@@ -37,7 +37,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/cibc.json
+++ b/data/account-providers/cibc.json
@@ -30,7 +30,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/citizensbank.json
+++ b/data/account-providers/citizensbank.json
@@ -30,6 +30,7 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "truelayer"
   ],
   "collections": [],

--- a/data/account-providers/coastalbank.json
+++ b/data/account-providers/coastalbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/column.json
+++ b/data/account-providers/column.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [],
   "webApplication": true,

--- a/data/account-providers/comdirect.json
+++ b/data/account-providers/comdirect.json
@@ -88,6 +88,7 @@
   ],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "ibanity",

--- a/data/account-providers/comerica-bank.json
+++ b/data/account-providers/comerica-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/commerzbank.json
+++ b/data/account-providers/commerzbank.json
@@ -101,6 +101,7 @@
   ],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "truelayer",
     "salt-edge"
   ],

--- a/data/account-providers/community-federal-savings-bank.json
+++ b/data/account-providers/community-federal-savings-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/coutts.json
+++ b/data/account-providers/coutts.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "COUTGB31XXX"

--- a/data/account-providers/cr-albal.json
+++ b/data/account-providers/cr-albal.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM150"

--- a/data/account-providers/cr-alcudia.json
+++ b/data/account-providers/cr-alcudia.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM096"

--- a/data/account-providers/cr-algemesi.json
+++ b/data/account-providers/cr-algemesi.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM117"

--- a/data/account-providers/cr-asturias.json
+++ b/data/account-providers/cr-asturias.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM059"

--- a/data/account-providers/cr-bantierra.json
+++ b/data/account-providers/cr-bantierra.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM191"

--- a/data/account-providers/cr-caixa-popular.json
+++ b/data/account-providers/cr-caixa-popular.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM159"

--- a/data/account-providers/cr-cajasiete.json
+++ b/data/account-providers/cr-cajasiete.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM076"

--- a/data/account-providers/cr-canete-torres.json
+++ b/data/account-providers/cr-canete-torres.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM104"

--- a/data/account-providers/cr-casas-ibanez.json
+++ b/data/account-providers/cr-casas-ibanez.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM127"

--- a/data/account-providers/cr-extremadura.json
+++ b/data/account-providers/cr-extremadura.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM009"

--- a/data/account-providers/cr-gijon.json
+++ b/data/account-providers/cr-gijon.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM007"

--- a/data/account-providers/cr-globalcaja.json
+++ b/data/account-providers/cr-globalcaja.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM190"

--- a/data/account-providers/cr-granada.json
+++ b/data/account-providers/cr-granada.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM023"

--- a/data/account-providers/cr-jaen.json
+++ b/data/account-providers/cr-jaen.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM067"

--- a/data/account-providers/cr-navarra.json
+++ b/data/account-providers/cr-navarra.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM008"

--- a/data/account-providers/cr-nueva-carteya.json
+++ b/data/account-providers/cr-nueva-carteya.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM098"

--- a/data/account-providers/cr-salamanca.json
+++ b/data/account-providers/cr-salamanca.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM016"

--- a/data/account-providers/cr-san-jose-almassora.json
+++ b/data/account-providers/cr-san-jose-almassora.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM130"

--- a/data/account-providers/cr-sur.json
+++ b/data/account-providers/cr-sur.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM187"

--- a/data/account-providers/cr-teruel.json
+++ b/data/account-providers/cr-teruel.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM080"

--- a/data/account-providers/cr-villamalea.json
+++ b/data/account-providers/cr-villamalea.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM144"

--- a/data/account-providers/cr-viva.json
+++ b/data/account-providers/cr-viva.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM060"

--- a/data/account-providers/cr-zamora.json
+++ b/data/account-providers/cr-zamora.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BCOEESMM085"

--- a/data/account-providers/cred-ai.json
+++ b/data/account-providers/cred-ai.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/credit-mutuel.json
+++ b/data/account-providers/credit-mutuel.json
@@ -43,6 +43,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://www.creditmutuel.fr/oauth2/en/devportal/stetpsd2-spec.html",
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "budget-insight",

--- a/data/account-providers/credit-suisse.json
+++ b/data/account-providers/credit-suisse.json
@@ -92,7 +92,9 @@
       "url": "https://psd2.ndgit-status.com/Credit-Suisse-Digital-ES"
     }
   ],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/cumberland.json
+++ b/data/account-providers/cumberland.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CMBSGB21"

--- a/data/account-providers/current.json
+++ b/data/account-providers/current.json
@@ -44,5 +44,8 @@
   "financialReports": [],
   "twitter": "https://twitter.com/current",
   "bloomberg": null,
-  "github": ""
+  "github": "",
+  "apiAggregators": [
+    "plaid"
+  ]
 }

--- a/data/account-providers/customersbank.json
+++ b/data/account-providers/customersbank.json
@@ -31,7 +31,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/cwbank.json
+++ b/data/account-providers/cwbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/cynergy-bank.json
+++ b/data/account-providers/cynergy-bank.json
@@ -35,7 +35,9 @@
   "slackCommunity": false,
   "apiAuth": [],
   "apiReferenceUrl": "https://openbanking.cynergybank.co.uk/store/",
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [
     {
       "label": "Account Information Service",

--- a/data/account-providers/danske-bank.json
+++ b/data/account-providers/danske-bank.json
@@ -98,6 +98,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "neonomics",
     "truelayer",
     "klarna",

--- a/data/account-providers/dave-bank.json
+++ b/data/account-providers/dave-bank.json
@@ -26,7 +26,9 @@
   "developerCommunityUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "webApplication": false,

--- a/data/account-providers/djurslands-bank-dk.json
+++ b/data/account-providers/djurslands-bank-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/dnb.json
+++ b/data/account-providers/dnb.json
@@ -185,6 +185,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "neonomics",

--- a/data/account-providers/eastwestbank.json
+++ b/data/account-providers/eastwestbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/emprisebank.json
+++ b/data/account-providers/emprisebank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/envel-ai.json
+++ b/data/account-providers/envel-ai.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/eqbank-ca.json
+++ b/data/account-providers/eqbank-ca.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/erzgebirgssparkasse.json
+++ b/data/account-providers/erzgebirgssparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "WELADED1STB"

--- a/data/account-providers/evobanco.json
+++ b/data/account-providers/evobanco.json
@@ -45,6 +45,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bridgeapi-io",
     "salt-edge"

--- a/data/account-providers/evolve-bank-and-trust.json
+++ b/data/account-providers/evolve-bank-and-trust.json
@@ -36,5 +36,8 @@
   "twitter": "https://www.twitter.com/getevolved1925",
   "crunchbase": null,
   "bloomberg": "https://www.bloomberg.com/profile/company/472048Z:US",
-  "github": ""
+  "github": "",
+  "apiAggregators": [
+    "plaid"
+  ]
 }

--- a/data/account-providers/fiare.json
+++ b/data/account-providers/fiare.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "ETICES21"

--- a/data/account-providers/fifth-third-bank.json
+++ b/data/account-providers/fifth-third-bank.json
@@ -34,6 +34,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "truelayer"
   ],
   "collections": [],

--- a/data/account-providers/fineco.json
+++ b/data/account-providers/fineco.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "FEBIITM2"

--- a/data/account-providers/first-trust-bank.json
+++ b/data/account-providers/first-trust-bank.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "FTBKGB2B"

--- a/data/account-providers/firstbusiness-bank.json
+++ b/data/account-providers/firstbusiness-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/firstrust.json
+++ b/data/account-providers/firstrust.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/frankfurter-sparkasse-de.json
+++ b/data/account-providers/frankfurter-sparkasse-de.json
@@ -39,6 +39,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/frostbank.json
+++ b/data/account-providers/frostbank.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/go2bank.json
+++ b/data/account-providers/go2bank.json
@@ -40,7 +40,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [
     {

--- a/data/account-providers/goldenpacificbank.json
+++ b/data/account-providers/goldenpacificbank.json
@@ -39,7 +39,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/goldmansachs.json
+++ b/data/account-providers/goldmansachs.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/halifax-uk.json
+++ b/data/account-providers/halifax-uk.json
@@ -129,6 +129,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "fintecture",
     "bridgeapi-io",

--- a/data/account-providers/hamburger-sparkasse.json
+++ b/data/account-providers/hamburger-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "HASPDEHHXXX"

--- a/data/account-providers/handelsbanken.json
+++ b/data/account-providers/handelsbanken.json
@@ -66,6 +66,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "neonomics",
     "klarna",

--- a/data/account-providers/harzsparkasse.json
+++ b/data/account-providers/harzsparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "NOLADE21HRZ"

--- a/data/account-providers/hmbradley.json
+++ b/data/account-providers/hmbradley.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/hsbckinetic-uk.json
+++ b/data/account-providers/hsbckinetic-uk.json
@@ -50,6 +50,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/hsbcnet.json
+++ b/data/account-providers/hsbcnet.json
@@ -37,6 +37,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": ""

--- a/data/account-providers/huntington-bank.json
+++ b/data/account-providers/huntington-bank.json
@@ -34,6 +34,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "truelayer"
   ],
   "collections": [],

--- a/data/account-providers/ica-banken-se.json
+++ b/data/account-providers/ica-banken-se.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "enablebanking",
     "enfuce",

--- a/data/account-providers/imagin.json
+++ b/data/account-providers/imagin.json
@@ -45,6 +45,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/investec.json
+++ b/data/account-providers/investec.json
@@ -144,7 +144,9 @@
   ],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/invoice2go-money.json
+++ b/data/account-providers/invoice2go-money.json
@@ -39,7 +39,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/ivella.json
+++ b/data/account-providers/ivella.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/jpmel.json
+++ b/data/account-providers/jpmel.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CHASGB22"

--- a/data/account-providers/kasseler-sparkasse.json
+++ b/data/account-providers/kasseler-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "HELADEF1KAS"

--- a/data/account-providers/keybank.json
+++ b/data/account-providers/keybank.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/knab-nl.json
+++ b/data/account-providers/knab-nl.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.knab.nl/",
   "apiAggregators": [
+    "plaid",
     "bankingsdk",
     "ibanity",
     "equensworldline",

--- a/data/account-providers/kreditbanken-dk.json
+++ b/data/account-providers/kreditbanken-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/kyffhausersparkasse-artern-sondershausen.json
+++ b/data/account-providers/kyffhausersparkasse-artern-sondershausen.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "HELADEF1KYF"

--- a/data/account-providers/la-banque-postale.json
+++ b/data/account-providers/la-banque-postale.json
@@ -44,6 +44,7 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "budget-insight",

--- a/data/account-providers/laboral-kutxa.json
+++ b/data/account-providers/laboral-kutxa.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CLPEES2M"

--- a/data/account-providers/letter-co.json
+++ b/data/account-providers/letter-co.json
@@ -32,7 +32,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/liberbank.json
+++ b/data/account-providers/liberbank.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "CECAESMM048"

--- a/data/account-providers/lili-co.json
+++ b/data/account-providers/lili-co.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/lincoln-savings-bank.json
+++ b/data/account-providers/lincoln-savings-bank.json
@@ -30,7 +30,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/luminor-bank.json
+++ b/data/account-providers/luminor-bank.json
@@ -58,6 +58,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.luminoropenbanking.com/",
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "enablebanking",
     "salt-edge"

--- a/data/account-providers/mandt-bank.json
+++ b/data/account-providers/mandt-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/marcus.json
+++ b/data/account-providers/marcus.json
@@ -39,7 +39,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [],
   "webApplication": true,

--- a/data/account-providers/marks-spencer-financial-services.json
+++ b/data/account-providers/marks-spencer-financial-services.json
@@ -49,6 +49,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://api.hsbc.com/",
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "truelayer",
     "banked",

--- a/data/account-providers/mbank.json
+++ b/data/account-providers/mbank.json
@@ -45,6 +45,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.api.mbank.pl/",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "banqup",
     "fintecture",

--- a/data/account-providers/mbna-uk.json
+++ b/data/account-providers/mbna-uk.json
@@ -123,6 +123,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "fintecture",
     "bridgeapi-io",

--- a/data/account-providers/mediobanca.json
+++ b/data/account-providers/mediobanca.json
@@ -87,6 +87,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/mediolanum.json
+++ b/data/account-providers/mediolanum.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BFIVESBB"

--- a/data/account-providers/mercury-co.json
+++ b/data/account-providers/mercury-co.json
@@ -25,7 +25,9 @@
   "developerCommunityUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "webApplication": true,

--- a/data/account-providers/metro-bank.json
+++ b/data/account-providers/metro-bank.json
@@ -80,6 +80,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "truelayer",
     "klarna",
     "moneyhub-enterprise"

--- a/data/account-providers/metropolitan-commercial-bank.json
+++ b/data/account-providers/metropolitan-commercial-bank.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/mettle-uk.json
+++ b/data/account-providers/mettle-uk.json
@@ -80,6 +80,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "friendlyscore",
     "truelayer",
     "moneyhub-enterprise"

--- a/data/account-providers/middlesexfederal.json
+++ b/data/account-providers/middlesexfederal.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/modebanking.json
+++ b/data/account-providers/modebanking.json
@@ -40,7 +40,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/montepio.json
+++ b/data/account-providers/montepio.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "MPIOPTPLXXX"

--- a/data/account-providers/monzo.json
+++ b/data/account-providers/monzo.json
@@ -71,6 +71,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "truelayer",
     "banked",

--- a/data/account-providers/nassauische-sparkasse.json
+++ b/data/account-providers/nassauische-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "NASSDE55XXX"

--- a/data/account-providers/nationwide-building-society.json
+++ b/data/account-providers/nationwide-building-society.json
@@ -1,7 +1,12 @@
 {
   "id": "nationwide-building-society",
-  "type": ["account"],
-  "bankType": ["retail","corporate"],
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "retail",
+    "corporate"
+  ],
   "name": "Nationwide Building Society",
   "legalName": "Nationwide Building Society",
   "ipoStatus": "private",
@@ -9,18 +14,20 @@
   "icon": "https://res.cloudinary.com/banq/image/upload/v1552296074/radar/icons/Nationwide_Building_Society.jpg",
   "websiteUrl": "https://www.nationwide.co.uk/",
   "ownership": [
-    { 
+    {
       "shareholderName": "Co-Operative of British Building Societies",
       "shareholderIconUrl": "https://res.cloudinary.com/banq/image/upload/v1552296074/radar/icons/Nationwide_Building_Society.jpg",
       "providerId": null,
-      "percentage": 100.0
+      "percentage": 100
     }
   ],
   "stateOwned": false,
   "countryHQ": "GB",
-  "countries": ["GB"],
+  "countries": [
+    "GB"
+  ],
   "compliance": [
-    { 
+    {
       "regulation": "OB",
       "status": "inProgress"
     }
@@ -33,7 +40,9 @@
     {
       "label": "Account and Transaction API",
       "type": "accountInformation",
-      "categories": ["accounts"],
+      "categories": [
+        "accounts"
+      ],
       "description": "Detailed Open Banking specifications for the Account and Transaction API that is available to Account Information Service Providers (AISPs) are available on the Open Banking websiteUrl.",
       "documentationUrl": "https://www.nationwide.co.uk/developer/open-banking-api",
       "apiReferenceUrl": null,
@@ -43,7 +52,9 @@
     {
       "label": "Payment API",
       "type": "paymentInitiation",
-      "categories": ["payments"],
+      "categories": [
+        "payments"
+      ],
       "description": "Detailed Open Banking specifications for the Payment Initiation API that is available to Payment Initiation Service Providers (PISPs) are available on the Open Banking websiteUrl.",
       "documentationUrl": "https://www.nationwide.co.uk/developer/open-banking-api",
       "apiReferenceUrl": null,
@@ -53,7 +64,9 @@
     {
       "label": "Discovery and Application Registration",
       "type": "auth",
-      "categories": ["auth"],
+      "categories": [
+        "auth"
+      ],
       "description": "Give customers the option to initiate payments via our BNP Paribas Fortis Payment Initiation API.",
       "documentationUrl": "https://www.nationwide.co.uk/developer/open-banking-api",
       "apiReferenceUrl": null,
@@ -63,7 +76,9 @@
     {
       "label": "Security",
       "type": "other",
-      "categories": ["products"],
+      "categories": [
+        "products"
+      ],
       "description": "The detailed Open Banking specification for the security model (Security Profile) is available on the central Open Banking websiteUrl (This link will open in a new window).",
       "documentationUrl": "https://www.nationwide.co.uk/developer/open-banking-api",
       "apiReferenceUrl": null,
@@ -73,6 +88,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "truelayer",
     "klarna",
     "token",

--- a/data/account-providers/natwest.json
+++ b/data/account-providers/natwest.json
@@ -88,6 +88,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "token",
     "yolt",
     "klarna",

--- a/data/account-providers/navy-federal-credit-union.json
+++ b/data/account-providers/navy-federal-credit-union.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/nbkc-bank.json
+++ b/data/account-providers/nbkc-bank.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiReferenceUrl": null,
   "apiChangelogUrl": null,
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "sdks": null,

--- a/data/account-providers/nearside.json
+++ b/data/account-providers/nearside.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/newday-amazon.json
+++ b/data/account-providers/newday-amazon.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": ""

--- a/data/account-providers/nordea.json
+++ b/data/account-providers/nordea.json
@@ -124,6 +124,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "budget-insight",
     "neonomics",

--- a/data/account-providers/nordfyns-bank-dk.json
+++ b/data/account-providers/nordfyns-bank-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/norisbank-de.json
+++ b/data/account-providers/norisbank-de.json
@@ -46,6 +46,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/nykredit.json
+++ b/data/account-providers/nykredit.json
@@ -35,7 +35,10 @@
   "slackCommunity": false,
   "apiAuth": [],
   "apiReferenceUrl": "https://apiportal00032.prod.bec.dk/openbanking/sandbox/APIs",
-  "apiAggregators": ["neonomics"],
+  "apiAggregators": [
+    "plaid",
+    "neonomics"
+  ],
   "apiProducts": [
     {
       "label": "Account Information Service",

--- a/data/account-providers/onefinance.json
+++ b/data/account-providers/onefinance.json
@@ -27,7 +27,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/openbank.json
+++ b/data/account-providers/openbank.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "OPENESMM"

--- a/data/account-providers/ostsachsische-sparkasse-dresden.json
+++ b/data/account-providers/ostsachsische-sparkasse-dresden.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "OSDDDE81XXX"

--- a/data/account-providers/ostseesparkasse-rostock.json
+++ b/data/account-providers/ostseesparkasse-rostock.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "NOLADE21ROS"

--- a/data/account-providers/oxygen-us.json
+++ b/data/account-providers/oxygen-us.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/pacwest.json
+++ b/data/account-providers/pacwest.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/penncommunitybank.json
+++ b/data/account-providers/penncommunitybank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/permanent-tsb.json
+++ b/data/account-providers/permanent-tsb.json
@@ -47,8 +47,8 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://www.permanenttsb.ie/developer-portal/api-overview/",
   "apiAggregators": [
-    "klarna",
-    "banqup"
+    "plaid",
+    "truelayer"
   ],
   "apiProducts": [
     {
@@ -90,9 +90,6 @@
   ],
   "apiStandards": [],
   "apiAccess": "verifiedTpp",
-  "apiAggregators": [
-    "truelayer"
-  ],  
   "webApplication": true,
   "mobileApps": [
     {

--- a/data/account-providers/petalcard.json
+++ b/data/account-providers/petalcard.json
@@ -30,7 +30,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/piermontbank.json
+++ b/data/account-providers/piermontbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/pko-bank-polski.json
+++ b/data/account-providers/pko-bank-polski.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developers.pkobp.pl/pl/",
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "klarna",
     "banqup",

--- a/data/account-providers/point-app.json
+++ b/data/account-providers/point-app.json
@@ -31,7 +31,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/popularbank.json
+++ b/data/account-providers/popularbank.json
@@ -39,7 +39,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/postbank-de.json
+++ b/data/account-providers/postbank-de.json
@@ -45,6 +45,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "equensworldline",
     "salt-edge"
   ],

--- a/data/account-providers/provident-bank.json
+++ b/data/account-providers/provident-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/qonto-eu.json
+++ b/data/account-providers/qonto-eu.json
@@ -40,7 +40,8 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
-  "bridgeapi-io"
+    "plaid",
+    "bridgeapi-io"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/rabobank.json
+++ b/data/account-providers/rabobank.json
@@ -163,6 +163,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "klarna",
     "salt-edge",
     "truelayer"

--- a/data/account-providers/rbs.json
+++ b/data/account-providers/rbs.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "RBOSGB2L"

--- a/data/account-providers/redriverbank.json
+++ b/data/account-providers/redriverbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/regiobank.json
+++ b/data/account-providers/regiobank.json
@@ -43,6 +43,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.devolksbank.nl/admin/app/api-catalog",
   "apiAggregators": [
+    "plaid",
     "bankingsdk",
     "klarna",
     "ibanity",

--- a/data/account-providers/regions-bank.json
+++ b/data/account-providers/regions-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/renta4.json
+++ b/data/account-providers/renta4.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "RENBESMM"

--- a/data/account-providers/rho-co.json
+++ b/data/account-providers/rho-co.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/ringkobing-landbobank-dk.json
+++ b/data/account-providers/ringkobing-landbobank-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/saalesparkasse.json
+++ b/data/account-providers/saalesparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "NOLADE21HAL"

--- a/data/account-providers/sabadell.json
+++ b/data/account-providers/sabadell.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BSABESBB"

--- a/data/account-providers/sablecard.json
+++ b/data/account-providers/sablecard.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/salzlandsparkasse.json
+++ b/data/account-providers/salzlandsparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "NOLADE21SES"

--- a/data/account-providers/seb-bank.json
+++ b/data/account-providers/seb-bank.json
@@ -68,6 +68,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "neonomics",
     "klarna",

--- a/data/account-providers/signature-bank.json
+++ b/data/account-providers/signature-bank.json
@@ -34,7 +34,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [],
   "webApplication": true,

--- a/data/account-providers/silvergate-bank.json
+++ b/data/account-providers/silvergate-bank.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "sdks": [],
   "webApplication": true,

--- a/data/account-providers/simple.json
+++ b/data/account-providers/simple.json
@@ -28,6 +28,7 @@
   "slackCommunity": false,
   "apiAuth": [],
   "apiAggregators": [
+    "plaid",
     "teller-io"
   ],
   "apiProducts": [],

--- a/data/account-providers/skjern-bank-dk.json
+++ b/data/account-providers/skjern-bank-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/sns-bank.json
+++ b/data/account-providers/sns-bank.json
@@ -43,6 +43,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.devolksbank.nl/admin/app/api-catalog",
   "apiAggregators": [
+    "plaid",
     "bankingsdk",
     "klarna",
     "ibanity",

--- a/data/account-providers/soc-gen.json
+++ b/data/account-providers/soc-gen.json
@@ -43,6 +43,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developer.societegenerale.fr/en",
   "apiAggregators": [
+    "plaid",
     "bankingsdk",
     "bridgeapi-io",
     "budget-insight",

--- a/data/account-providers/sofi.json
+++ b/data/account-providers/sofi.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/sparda-bank-west.json
+++ b/data/account-providers/sparda-bank-west.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "GENODED1SPW"

--- a/data/account-providers/sparekassen-sjaelland-fyn-dk.json
+++ b/data/account-providers/sparekassen-sjaelland-fyn-dk.json
@@ -56,6 +56,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "enablebanking"
   ],
   "webApplication": true,

--- a/data/account-providers/sparkasse-an-der-lippe.json
+++ b/data/account-providers/sparkasse-an-der-lippe.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "WELADED1LUN"

--- a/data/account-providers/sparkasse-de.json
+++ b/data/account-providers/sparkasse-de.json
@@ -69,6 +69,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "truelayer",
     "salt-edge"
   ],

--- a/data/account-providers/spursecuritybank.json
+++ b/data/account-providers/spursecuritybank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/standard-chartered.json
+++ b/data/account-providers/standard-chartered.json
@@ -110,6 +110,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/starfinancial.json
+++ b/data/account-providers/starfinancial.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/stashinvest.json
+++ b/data/account-providers/stashinvest.json
@@ -27,7 +27,9 @@
   "openBankProjectUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "webApplication": true,

--- a/data/account-providers/stearnsbank.json
+++ b/data/account-providers/stearnsbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/step.json
+++ b/data/account-providers/step.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/stridebank.json
+++ b/data/account-providers/stridebank.json
@@ -30,7 +30,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/suttonbank.json
+++ b/data/account-providers/suttonbank.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/swedbank.json
+++ b/data/account-providers/swedbank.json
@@ -130,6 +130,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "klarna",
     "salt-edge",

--- a/data/account-providers/sydbank.json
+++ b/data/account-providers/sydbank.json
@@ -38,6 +38,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developers.bankdata.dk",
   "apiAggregators": [
+    "plaid",
     "neonomics",
     "klarna",
     "tink",

--- a/data/account-providers/t-mobilemoney.json
+++ b/data/account-providers/t-mobilemoney.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/tabbank.json
+++ b/data/account-providers/tabbank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/targobank-de.json
+++ b/data/account-providers/targobank-de.json
@@ -44,6 +44,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "equensworldline",
     "truelayer",

--- a/data/account-providers/taunus-sparkasse.json
+++ b/data/account-providers/taunus-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "HELADEF1TSK"

--- a/data/account-providers/the-co-operative-bank.json
+++ b/data/account-providers/the-co-operative-bank.json
@@ -44,6 +44,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://www.co-operativebank.co.uk/onlinebanking/open-banking/third-party-providers",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "moneyhub-enterprise"
   ],

--- a/data/account-providers/tide.json
+++ b/data/account-providers/tide.json
@@ -87,6 +87,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "plaid",
     "truelayer",
     "salt-edge"
   ],

--- a/data/account-providers/triodos-bank.json
+++ b/data/account-providers/triodos-bank.json
@@ -46,6 +46,7 @@
   "apiReferenceUrl": "https://developer.triodos.com/reference",
   "apiChangelogUrl": "https://developer.triodos.com/changelog",
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "bankingsdk",
     "ibanity",

--- a/data/account-providers/truist.json
+++ b/data/account-providers/truist.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/tsb.json
+++ b/data/account-providers/tsb.json
@@ -105,6 +105,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "truelayer",
     "salt-edge",
@@ -160,7 +161,7 @@
   "partnerships": [],
   "rewardPartners": [],
   "integrations": [
-  "moneyhub-enterprise"
+    "moneyhub-enterprise"
   ],
   "platforms": [],
   "awards": []

--- a/data/account-providers/ubank-jellico.json
+++ b/data/account-providers/ubank-jellico.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/ubi-banca.json
+++ b/data/account-providers/ubi-banca.json
@@ -36,6 +36,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://www.cbiglobe.com/Wiki/?RARequestUrl=Wiki",
   "apiAggregators": [
+    "plaid",
     "klarna",
     "equensworldline",
     "truelayer"

--- a/data/account-providers/unicaja.json
+++ b/data/account-providers/unicaja.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "UCJAES2M"

--- a/data/account-providers/unionbank.json
+++ b/data/account-providers/unionbank.json
@@ -28,6 +28,7 @@
   "slackCommunity": false,
   "apiAuth": [],
   "apiAggregators": [
+    "plaid",
     "truelayer"
   ],
   "apiProducts": [],

--- a/data/account-providers/usaa.json
+++ b/data/account-providers/usaa.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/valley-bank.json
+++ b/data/account-providers/valley-bank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/vanquis-uk.json
+++ b/data/account-providers/vanquis-uk.json
@@ -107,6 +107,7 @@
   ],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "collections": [],

--- a/data/account-providers/venmo.json
+++ b/data/account-providers/venmo.json
@@ -44,7 +44,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/vereinigte-sparkasse-im-markischen-kreis.json
+++ b/data/account-providers/vereinigte-sparkasse-im-markischen-kreis.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "WELADED1PLB"

--- a/data/account-providers/vistabank.json
+++ b/data/account-providers/vistabank.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/volksbank-raiffeisen-eg.json
+++ b/data/account-providers/volksbank-raiffeisen-eg.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "GENODEM1AHL"

--- a/data/account-providers/volksbank-raiffeisen-sulingen.json
+++ b/data/account-providers/volksbank-raiffeisen-sulingen.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "GENODEF1SUL"

--- a/data/account-providers/volksbank-raiffeisen-vb-hm.json
+++ b/data/account-providers/volksbank-raiffeisen-vb-hm.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "GENODEM1DLR"

--- a/data/account-providers/volksbank-raiffeisen-vr-internet.json
+++ b/data/account-providers/volksbank-raiffeisen-vr-internet.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "GENODEF1LUK"

--- a/data/account-providers/volksbanken-raiffeisenbanken.json
+++ b/data/account-providers/volksbanken-raiffeisenbanken.json
@@ -39,6 +39,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "plaid",
     "nordigen",
     "equensworldline",
     "truelayer"

--- a/data/account-providers/wartburg-sparkasse.json
+++ b/data/account-providers/wartburg-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "HELADEF1WAK"

--- a/data/account-providers/webbank.json
+++ b/data/account-providers/webbank.json
@@ -35,7 +35,9 @@
   "openBankProjectUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "apiProducts": [],
   "apiStandards": [],
   "webApplication": false,

--- a/data/account-providers/weser-elbe-sparkasse.json
+++ b/data/account-providers/weser-elbe-sparkasse.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "plaid",
     "salt-edge"
   ],
   "swiftCode": "BRLADE21BRS"

--- a/data/account-providers/whitakerbank.json
+++ b/data/account-providers/whitakerbank.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/winden-co.json
+++ b/data/account-providers/winden-co.json
@@ -33,7 +33,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/wise-us.json
+++ b/data/account-providers/wise-us.json
@@ -29,7 +29,9 @@
   "apiAuth": [],
   "apiProducts": [],
   "apiStandards": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/x1creditcard.json
+++ b/data/account-providers/x1creditcard.json
@@ -32,7 +32,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [],

--- a/data/account-providers/yorkshire-building-society.json
+++ b/data/account-providers/yorkshire-building-society.json
@@ -17,7 +17,7 @@
       "shareholderName": "Yorkshire Building Society Members",
       "shareholderIconUrl": "https://res.cloudinary.com/banq/image/upload/v1552654979/radar/icons/Yorkshire_Building_Society.jpg",
       "providerId": "yorkshire-building-society",
-      "percentage": 100.0,
+      "percentage": 100,
       "sourceUrl": "https://www.ybs.co.uk/your-society/member-benefits/what-it-means-to-be-a-member/index.html"
     }
   ],
@@ -88,6 +88,7 @@
     }
   ],
   "apiAggregators": [
+    "plaid",
     "moneyhub-enterprise",
     "truelayer",
     "salt-edge"


### PR DESCRIPTION
Adding `plaid` to banks' `apiAggregators` that are supported by Plaid.

Some changes are just formatting, e.g.
```
  "bankType": ["challenger"],
```
to
```
  "bankType": [
    "challenger"
  ],
```