### PR TITLE
Remove Ally API support, add Teller to aggregator list

### DIFF
--- a/data/account-providers/ally.json
+++ b/data/account-providers/ally.json
@@ -39,7 +39,8 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
-    "plaid"
+    "plaid",
+    "teller-io"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/ally.json
+++ b/data/account-providers/ally.json
@@ -12,7 +12,7 @@
   "ipoStatus": "public",
   "stockSymbol": "ALLY",
   "verified": false,
-  "status": "live",
+  "status": "discontinued",
   "icon": "https://res.cloudinary.com/apideck/image/upload/v1637113078/radar/icons/ally.jpg",
   "websiteUrl": "https://www.ally.com/",
   "ownership": [],
@@ -23,15 +23,15 @@
   ],
   "compliance": [],
   "sandbox": {
-    "status": "available",
-    "sourceUrl": "https://developer.ally.com/"
+    "status": "unavailable",
+    "sourceUrl": null
   },
-  "developerPortalUrl": "https://developer.ally.com/",
+  "developerPortalUrl": null,
   "developerCommunityUrl": null,
   "openBankProjectUrl": null,
   "slackCommunity": false,
   "apiAuth": [],
-  "apiReferenceUrl": "https://www.ally.com/api/invest/documentation",
+  "apiReferenceUrl": null,
   "apiPerformanceReports": [],
   "apiServerEndpoints": [],
   "apiSpecs": [],


### PR DESCRIPTION
Ally no longer has an API, and [developer.ally.com](https://developer.ally.com) and [ally.com/api/invest/documentation](https://www.ally.com/api/invest/documentation) return 404s.

Additionally, [Teller](https://teller.io) supports Ally.