### PR TITLE
Update Fiskil coverage

### DIFF
--- a/data/account-providers/anz-bank-new-zealand-limited.json
+++ b/data/account-providers/anz-bank-new-zealand-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/arab-bank-australia-limited.json
+++ b/data/account-providers/arab-bank-australia-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/asb.json
+++ b/data/account-providers/asb.json
@@ -21,7 +21,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "akahu",
-    "lunchflow"
+    "lunchflow",
+    "fiskil"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/auswide-bank-ltd.json
+++ b/data/account-providers/auswide-bank-ltd.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/bank-of-china-australia-limited.json
+++ b/data/account-providers/bank-of-china-australia-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/bank-of-sydney-ltd.json
+++ b/data/account-providers/bank-of-sydney-ltd.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/bnz.json
+++ b/data/account-providers/bnz.json
@@ -21,7 +21,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "akahu",
-    "lunchflow"
+    "lunchflow",
+    "fiskil"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/central-murray-credit-union-limited.json
+++ b/data/account-providers/central-murray-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/central-west-credit-union-limited.json
+++ b/data/account-providers/central-west-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/coastline-bank-au.json
+++ b/data/account-providers/coastline-bank-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/credit-union-sa-ltd.json
+++ b/data/account-providers/credit-union-sa-ltd.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/family-first-credit-union-limited.json
+++ b/data/account-providers/family-first-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/first-option-bank-ltd-au.json
+++ b/data/account-providers/first-option-bank-ltd-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/gateway-bank-ltd-au.json
+++ b/data/account-providers/gateway-bank-ltd-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/geelong-bank-au.json
+++ b/data/account-providers/geelong-bank-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/greater-bank-limited.json
+++ b/data/account-providers/greater-bank-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/horizon-credit-union-ltd.json
+++ b/data/account-providers/horizon-credit-union-ltd.json
@@ -23,7 +23,8 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid",
+    "fiskil"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/hsbc-bank-australia-limited.json
+++ b/data/account-providers/hsbc-bank-australia-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/hume-bank-limited.json
+++ b/data/account-providers/hume-bank-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/imb-au.json
+++ b/data/account-providers/imb-au.json
@@ -64,7 +64,9 @@
   ],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/kiwibank.json
+++ b/data/account-providers/kiwibank.json
@@ -21,7 +21,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "akahu",
-    "lunchflow"
+    "lunchflow",
+    "fiskil"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/laboratories-credit-union-limited.json
+++ b/data/account-providers/laboratories-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/maitland-mutual-building-society-limited.json
+++ b/data/account-providers/maitland-mutual-building-society-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/mystate-bank-limited.json
+++ b/data/account-providers/mystate-bank-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/newcastle-permanent-building-society-limited.json
+++ b/data/account-providers/newcastle-permanent-building-society-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/northern-inland-credit-union-limited.json
+++ b/data/account-providers/northern-inland-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/orange-credit-union-limited.json
+++ b/data/account-providers/orange-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/police-bank-ltd.json
+++ b/data/account-providers/police-bank-ltd.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/police-credit-union-limited.json
+++ b/data/account-providers/police-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/qudos-mutual-limited.json
+++ b/data/account-providers/qudos-mutual-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/queensland-country-bank-limited-au.json
+++ b/data/account-providers/queensland-country-bank-limited-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/racq-bank-au.json
+++ b/data/account-providers/racq-bank-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/regionalaustraliabank-au.json
+++ b/data/account-providers/regionalaustraliabank-au.json
@@ -38,7 +38,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/southern-cross-credit-union-ltd-au.json
+++ b/data/account-providers/southern-cross-credit-union-ltd-au.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/summerland-credit-union-limited.json
+++ b/data/account-providers/summerland-credit-union-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/teachers-mutual-bank-limited.json
+++ b/data/account-providers/teachers-mutual-bank-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/the-capricornian-ltd.json
+++ b/data/account-providers/the-capricornian-ltd.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/ubank-au.json
+++ b/data/account-providers/ubank-au.json
@@ -64,7 +64,9 @@
   ],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/unity-bank-limited.json
+++ b/data/account-providers/unity-bank-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/up-banking-au.json
+++ b/data/account-providers/up-banking-au.json
@@ -58,7 +58,9 @@
   ],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/westpac-new-zealand-limited-a-wholly-owned-subsidi.json
+++ b/data/account-providers/westpac-new-zealand-limited-a-wholly-owned-subsidi.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "fiskil"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/api-aggregators/fiskil.json
+++ b/data/api-aggregators/fiskil.json
@@ -9,7 +9,7 @@
   "countryHQ": "AU",
   "marketFocus": "Australia and New Zealand",
   "verified": false,
-  "description": "Open finance data aggregator for banking across Australia (Consumer Data Right) and New Zealand",
+  "description": "Open finance platform providing secure access to financial data across Australia and New Zealand",
   "marketCoverage": {
     "live": ["AU", "NZ"]
   },

--- a/data/api-aggregators/fiskil.json
+++ b/data/api-aggregators/fiskil.json
@@ -3,13 +3,24 @@
   "label": "Fiskil",
   "website": "https://fiskil.com/",
   "iconUrl": "https://fiskil.com/favicon.ico",
-  "twitter": "fiskilhq",
   "developerPortalUrl": "https://docs.fiskil.com/",
+  "institutionStatusUrl": "https://www.fiskil.com/institution-status",
+  "twitter": "fiskilhq",
   "countryHQ": "AU",
-  "marketFocus": "Australia",
+  "marketFocus": "Australia and New Zealand",
   "verified": false,
-  "description": "Australian Consumer Data Right (CDR) data aggregator for banking, energy, and telco",
+  "description": "Open finance data aggregator for banking, energy, and telco across Australia (Consumer Data Right) and New Zealand",
   "marketCoverage": {
-    "live": ["AU"]
+    "live": ["AU", "NZ"]
+  },
+  "bankCount": 121,
+  "lastUpdated": "2026-06-27T04:56:50Z",
+  "coverage": {
+    "byCountry": {
+      "AU": 116,
+      "NZ": 5
+    },
+    "banks": 121,
+    "total": 121
   }
 }

--- a/data/api-aggregators/fiskil.json
+++ b/data/api-aggregators/fiskil.json
@@ -9,7 +9,7 @@
   "countryHQ": "AU",
   "marketFocus": "Australia and New Zealand",
   "verified": false,
-  "description": "Open finance data aggregator for banking, energy, and telco across Australia (Consumer Data Right) and New Zealand",
+  "description": "Open finance data aggregator for banking across Australia (Consumer Data Right) and New Zealand",
   "marketCoverage": {
     "live": ["AU", "NZ"]
   },


### PR DESCRIPTION
### Summary
Updates the Fiskil API aggregator listing with accurate coverage.

### Changes
- `data/api-aggregators/fiskil.json`: corrected coverage to **121 banks** (`bankCount` + `coverage.byCountry`: AU 116, NZ 5), added `marketCoverage.live` for AU + NZ, added `institutionStatusUrl`, and broadened the description/marketFocus to cover both markets.
- Tagged 5 New Zealand banks with `fiskil` in their `apiAggregators` arrays: ASB, BNZ, Kiwibank, ANZ New Zealand, and Westpac New Zealand.

### Source
Fiskil site.

### Validation
- `fiskil.json` passes `npm run validate-aggregators`.
- `fiskil` is already registered in the `apiAggregators` enum in `schema.json`.
