### PR TITLE
Add open-banking.io as API aggregator

### DIFF
--- a/data/api-aggregators/open-banking-io.json
+++ b/data/api-aggregators/open-banking-io.json
@@ -1,0 +1,9 @@
+{
+  "id": "open-banking-io",
+  "label": "open-banking.io",
+  "website": "https://open-banking.io/",
+  "iconUrl": "https://cdn.brandfetch.io/open-banking.io/fallback/lettermark/theme/dark/h/256/w/256/icon",
+  "developerPortalUrl": "https://open-banking.io/",
+  "countryHQ": "DK",
+  "verified": false
+}


### PR DESCRIPTION
Adds open-banking.io, a self-hostable PSD2 account aggregation API for EU/UK banks (AISP/PISP), headquartered in Denmark. Entry follows the api-aggregators schema with the required fields (id, label, website, iconUrl, countryHQ).

Disclosure: I am affiliated with this project. The Open Banking Tracker listing was discussed with Gertjan; a backlink to Apideck/OBT on our site is in progress. Happy to add more data points or adjust as needed.