### PR TITLE
Tag 20 Danish banks supported by open-banking.io

### DIFF
--- a/data/account-providers/arbejdernes-landsbank.json
+++ b/data/account-providers/arbejdernes-landsbank.json
@@ -103,7 +103,8 @@
     "gocardless",
     "lunchflow",
     "plaid",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "bic": "ALBADKKK"
 }

--- a/data/account-providers/coop-bank.json
+++ b/data/account-providers/coop-bank.json
@@ -26,7 +26,8 @@
     "gocardless",
     "lunchflow",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/danske-bank.json
+++ b/data/account-providers/danske-bank.json
@@ -114,7 +114,8 @@
     "truelayer",
     "volt",
     "yapily",
-    "yolt"
+    "yolt",
+    "open-banking-io"
   ],
   "collections": [
     "cma9"

--- a/data/account-providers/handelsbanken-dk.json
+++ b/data/account-providers/handelsbanken-dk.json
@@ -82,7 +82,8 @@
     "salt-edge",
     "tink",
     "truelayer",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/jyske-bank-corporate.json
+++ b/data/account-providers/jyske-bank-corporate.json
@@ -24,7 +24,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
-    "lunchflow"
+    "lunchflow",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/jyske-bank.json
+++ b/data/account-providers/jyske-bank.json
@@ -90,7 +90,8 @@
     "lunchflow",
     "neonomics",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/kreditbanken.json
+++ b/data/account-providers/kreditbanken.json
@@ -59,7 +59,8 @@
     "lunchflow",
     "plaid",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/lunar-bank.json
+++ b/data/account-providers/lunar-bank.json
@@ -7,7 +7,7 @@
     "challenger"
   ],
   "name": "Lunar",
-  "description": "Lunar\u2019s banking app makes managing your spending, budget and savings easy with its sublime user experience for both personal and business finance.",
+  "description": "Lunar’s banking app makes managing your spending, budget and savings easy with its sublime user experience for both personal and business finance.",
   "legalName": "Lunar Bank A/S",
   "ipoStatus": "private",
   "stockSymbol": null,
@@ -39,7 +39,8 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
-    "tink"
+    "tink",
+    "open-banking-io"
   ],
   "collections": [],
   "webApplication": false,

--- a/data/account-providers/nordea-business.json
+++ b/data/account-providers/nordea-business.json
@@ -24,7 +24,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
-    "lunchflow"
+    "lunchflow",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/nordea-corporate.json
+++ b/data/account-providers/nordea-corporate.json
@@ -27,7 +27,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
-    "lunchflow"
+    "lunchflow",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/nordea-personal.json
+++ b/data/account-providers/nordea-personal.json
@@ -24,7 +24,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
-    "lunchflow"
+    "lunchflow",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/nordfyns-bank.json
+++ b/data/account-providers/nordfyns-bank.json
@@ -59,7 +59,8 @@
     "lunchflow",
     "plaid",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/nykredit.json
+++ b/data/account-providers/nykredit.json
@@ -41,7 +41,8 @@
     "neonomics",
     "plaid",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "apiProducts": [
     {

--- a/data/account-providers/ringkjobing-landbobank.json
+++ b/data/account-providers/ringkjobing-landbobank.json
@@ -26,7 +26,8 @@
     "gocardless",
     "lunchflow",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/skjern-bank.json
+++ b/data/account-providers/skjern-bank.json
@@ -60,7 +60,8 @@
     "plaid",
     "tink",
     "volt",
-    "yapily"
+    "yapily",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/spar-nord-bank.json
+++ b/data/account-providers/spar-nord-bank.json
@@ -111,7 +111,8 @@
     "gocardless",
     "lunchflow",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "bic": "SPNODK22"
 }

--- a/data/account-providers/sparekassen-sjaelland-fyn.json
+++ b/data/account-providers/sparekassen-sjaelland-fyn.json
@@ -58,7 +58,8 @@
     "gocardless",
     "lunchflow",
     "plaid",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/sydbank-corporate.json
+++ b/data/account-providers/sydbank-corporate.json
@@ -24,7 +24,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
-    "lunchflow"
+    "lunchflow",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/sydbank.json
+++ b/data/account-providers/sydbank.json
@@ -47,7 +47,8 @@
     "salt-edge",
     "tink",
     "volt",
-    "yaxi"
+    "yaxi",
+    "open-banking-io"
   ],
   "apiProducts": [
     {

--- a/data/account-providers/vestjysk-bank.json
+++ b/data/account-providers/vestjysk-bank.json
@@ -26,7 +26,8 @@
     "gocardless",
     "lunchflow",
     "tink",
-    "volt"
+    "volt",
+    "open-banking-io"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/schema.json
+++ b/schema.json
@@ -434,6 +434,7 @@
               "neonomics",
               "nordic-api-gateway",
               "nordigen",
+              "open-banking-io",
               "openwrks",
               "plaid",
               "pluggy",


### PR DESCRIPTION
## Summary

As requested by @gertjan in our email exchange, this PR tags the Danish banks supported by open-banking.io with the `open-banking-io` aggregator ID in their `apiAggregators` arrays.

## Changes

- **Register `open-banking-io`** in the `apiAggregators` enum in `schema.json` (alphabetical order, between `nordigen` and `openwrks`).
- **Tag 20 major Danish consumer banks** (countryHQ=DK) that have PSD2 API support:

  Danske Bank, Nordea (Personal/Business/Corporate), Jyske Bank (+ Corporate), Sydbank (+ Corporate), Spar Nord Bank, Nykredit, Arbejdernes Landsbank, Handelsbanken DK, Lunar, Coop Bank, Kreditbanken, Nordfyns Bank, Skjern Bank, Sparekassen Sjælland-Fyn, Ringkjøbing Landbobank, Vestjysk Bank.

These are the primary consumer-facing banks with active PSD2 APIs that open-banking.io connects to. The coverage list may be expanded in follow-up PRs as we validate additional banks.

Related: #572 (aggregator registration, merged).