### PR TITLE
Refresh open-banking.io aggregator profile

### DIFF
--- a/data/api-aggregators/open-banking-io.json
+++ b/data/api-aggregators/open-banking-io.json
@@ -3,7 +3,12 @@
   "label": "open-banking.io",
   "website": "https://open-banking.io/",
   "iconUrl": "https://cdn.brandfetch.io/open-banking.io/fallback/lettermark/theme/dark/h/256/w/256/icon",
-  "developerPortalUrl": "https://open-banking.io/",
+  "developerPortalUrl": "https://open-banking.io/en/developers",
   "countryHQ": "DK",
-  "verified": false
+  "verified": false,
+  "marketCoverage": {
+    "live": [
+      "DK"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #573 (which tagged 20 Danish banks with the `open-banking-io` aggregator). Refreshes the `open-banking.io` aggregator profile itself:

- **`developerPortalUrl`** → `https://open-banking.io/en/developers` (the actual SDK/API docs page) instead of the marketing homepage.
- **`marketCoverage.live`** → `["DK"]`, matching the 20 Danish consumer banks now tagged with `open-banking-io`. All currently-tagged banks are `countryHQ=DK`.

### Notes / what was verified
- Checked open-banking.io and their GitHub org (`github.com/open-banking-io`): zero-knowledge open banking SDKs (.NET, Node, Python, Rust, Go, Java, Ruby, PHP) + CLI. HQ remains DK.
- No public Twitter/X handle found, so none was added.
- `verified` left as `false`.
- Coverage list can be expanded as additional markets are validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)