### PR TITLE
Add Insurely as an API aggregator with its 30 Swedish institutions

### DIFF
--- a/data/account-providers/alandsbanken-abp-finlandsvensk-filial.json
+++ b/data/account-providers/alandsbanken-abp-finlandsvensk-filial.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "ALANDSBANKEN ABP (FINLAND),SVENSK FILIAL",
-  "legalName": "ALANDSBANKEN ABP (FINLAND),SVENSK FILIAL",
+  "name": "Ålandsbanken Abp (Finland), Svensk Filial",
+  "legalName": "Ålandsbanken Abp (Finland), Svensk Filial",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.alandsbankenabpfinlandsvenskfilial.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.alandsbanken.se.ico",
+  "websiteUrl": "https://www.alandsbanken.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "zenith"
   ],
   "ownership": [],

--- a/data/account-providers/avanza.json
+++ b/data/account-providers/avanza.json
@@ -10,8 +10,8 @@
   "legalName": "Avanza",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.avanza.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.avanza.se.ico",
+  "websiteUrl": "https://www.avanza.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,9 +23,11 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "tink"
   ],
   "ownership": [],
   "stateOwned": false,
-  "stockSymbol": null
+  "stockSymbol": null,
+  "bic": "AVANSESX"
 }

--- a/data/account-providers/bank-norwegian-decoupled.json
+++ b/data/account-providers/bank-norwegian-decoupled.json
@@ -10,8 +10,8 @@
   "legalName": "Bank Norwegian Decoupled",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.bank-norwegian-decoupled.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.banknorwegian.se.ico",
+  "websiteUrl": "https://www.banknorwegian.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/danske-bank-se.json
+++ b/data/account-providers/danske-bank-se.json
@@ -10,8 +10,8 @@
   "legalName": "DANSKE BANK",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.danskebankse.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.danskebank.se.ico",
+  "websiteUrl": "https://danskebank.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "plaid",
     "zenith"
   ],

--- a/data/account-providers/ekobanken-medlemsbank.json
+++ b/data/account-providers/ekobanken-medlemsbank.json
@@ -10,8 +10,8 @@
   "legalName": "EKOBANKEN MEDLEMSBANK",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.ekobankenmedlemsbank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.ekobanken.se.ico",
+  "websiteUrl": "https://www.ekobanken.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "volt"

--- a/data/account-providers/handelsbanken-se.json
+++ b/data/account-providers/handelsbanken-se.json
@@ -10,8 +10,8 @@
   "legalName": "Handelsbanken (SE)",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.handelsbanken-se.com.ico",
-  "websiteUrl": "https://www.handelsbanken.com/",
+  "icon": "https://icons.duckduckgo.com/ip3/www.handelsbanken.se.ico",
+  "websiteUrl": "https://www.handelsbanken.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,9 +23,11 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "plaid"
   ],
   "ownership": [],
   "stateOwned": false,
-  "stockSymbol": null
+  "stockSymbol": null,
+  "bic": "HANDSESS"
 }

--- a/data/account-providers/ica-banken.json
+++ b/data/account-providers/ica-banken.json
@@ -57,6 +57,7 @@
     "enablebanking",
     "enfuce",
     "gocardless",
+    "insurely",
     "lunchflow",
     "nordigen",
     "plaid",

--- a/data/account-providers/ikano-banken-ab-publ.json
+++ b/data/account-providers/ikano-banken-ab-publ.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "IKANO BANKEN AB (PUBL)",
-  "legalName": "IKANO BANKEN AB (PUBL)",
+  "name": "Ikano Banken AB (publ)",
+  "legalName": "Ikano Banken AB (publ)",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.ikanobankenabpubl.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.ikanobank.se.ico",
+  "websiteUrl": "https://www.ikanobank.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "zenith"
   ],
   "ownership": [],

--- a/data/account-providers/jak-medlemsbank.json
+++ b/data/account-providers/jak-medlemsbank.json
@@ -10,8 +10,8 @@
   "legalName": "JAK MEDLEMSBANK",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.jakmedlemsbank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.jak.se.ico",
+  "websiteUrl": "https://www.jak.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/klarna.json
+++ b/data/account-providers/klarna.json
@@ -42,6 +42,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://developers.klarna.com/api/",
   "apiAggregators": [
+    "insurely",
     "klarna"
   ],
   "apiProducts": [
@@ -235,5 +236,6 @@
     }
   ],
   "platforms": [],
-  "awards": []
+  "awards": [],
+  "bic": "KLRNSESS"
 }

--- a/data/account-providers/laensfoersaekringar-bank.json
+++ b/data/account-providers/laensfoersaekringar-bank.json
@@ -10,8 +10,8 @@
   "legalName": "Länsförsäkringar Bank",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.laensfoersaekringar-bank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://www.lansforsakringar.se/favicon.ico",
+  "websiteUrl": "https://www.lansforsakringar.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "tink",

--- a/data/account-providers/lan-spar-sverige.json
+++ b/data/account-providers/lan-spar-sverige.json
@@ -10,8 +10,8 @@
   "legalName": "Lån & Spar Sverige",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.lan-spar-sverige.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.lsb.se.ico",
+  "websiteUrl": "https://www.lsb.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/marginalen-bank-bankaktiebolag-se.json
+++ b/data/account-providers/marginalen-bank-bankaktiebolag-se.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "MARGINALEN BANK BANKAKTIEBOLAG",
-  "legalName": "MARGINALEN BANK BANKAKTIEBOLAG",
+  "name": "Marginalen Bank Bankaktiebolag",
+  "legalName": "Marginalen Bank Bankaktiebolag",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.marginalenbankbankaktiebolagse.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.marginalen.se.ico",
+  "websiteUrl": "https://www.marginalen.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/medmera-bank-ab.json
+++ b/data/account-providers/medmera-bank-ab.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "MEDMERA BANK AB",
-  "legalName": "MEDMERA BANK AB",
+  "name": "MedMera Bank AB",
+  "legalName": "MedMera Bank AB",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.medmerabankab.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/medmerabank.se.ico",
+  "websiteUrl": "https://medmerabank.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/morrow-bank.json
+++ b/data/account-providers/morrow-bank.json
@@ -10,8 +10,8 @@
   "legalName": "Morrow Bank",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.morrow-bank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/morrowbank.com.ico",
+  "websiteUrl": "https://morrowbank.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/nordax-finans-ab-publ.json
+++ b/data/account-providers/nordax-finans-ab-publ.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "NORDAX FINANS AB (PUBL)",
-  "legalName": "NORDAX FINANS AB (PUBL)",
+  "name": "Nordax Finans AB (publ)",
+  "legalName": "Nordax Finans AB (publ)",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.nordaxfinansabpubl.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.nordax.se.ico",
+  "websiteUrl": "https://www.nordax.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/nordea-se.json
+++ b/data/account-providers/nordea-se.json
@@ -10,7 +10,7 @@
   "legalName": "Nordea (SE)",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.nordea-se.com.ico",
+  "icon": "https://icons.duckduckgo.com/ip3/www.nordea.se.ico",
   "websiteUrl": "https://www.nordea.com/en",
   "countryHQ": "SE",
   "countries": [
@@ -23,9 +23,11 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "plaid"
   ],
   "ownership": [],
   "stateOwned": false,
-  "stockSymbol": null
+  "stockSymbol": null,
+  "bic": "NDEASESS"
 }

--- a/data/account-providers/nordnet-bank-ab.json
+++ b/data/account-providers/nordnet-bank-ab.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "NORDNET BANK AB",
-  "legalName": "NORDNET BANK AB",
+  "name": "Nordnet Bank AB",
+  "legalName": "Nordnet Bank AB",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.nordnetbankab.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.nordnet.se.ico",
+  "websiteUrl": "https://www.nordnet.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/ok-q8-bank.json
+++ b/data/account-providers/ok-q8-bank.json
@@ -10,8 +10,8 @@
   "legalName": "OK-Q8 Bank",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.ok-q8-bank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.okq8.se.ico",
+  "websiteUrl": "https://www.okq8.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci"
   ],

--- a/data/account-providers/remember.json
+++ b/data/account-providers/remember.json
@@ -10,8 +10,8 @@
   "legalName": "re:member",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.remember.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.remember.se.ico",
+  "websiteUrl": "https://www.remember.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "tink"
   ],
   "ownership": [],

--- a/data/account-providers/resurs-bank.json
+++ b/data/account-providers/resurs-bank.json
@@ -62,6 +62,7 @@
     "enablebanking",
     "enfuce",
     "gocardless",
+    "insurely",
     "lunchflow",
     "neonomics",
     "salt-edge",

--- a/data/account-providers/rocker.json
+++ b/data/account-providers/rocker.json
@@ -43,7 +43,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "collections": [],
   "webApplication": false,
   "mobileApps": [

--- a/data/account-providers/santander-consumer-bank-as-norge-sverige-filial.json
+++ b/data/account-providers/santander-consumer-bank-as-norge-sverige-filial.json
@@ -6,12 +6,12 @@
   "bankType": [
     "retail"
   ],
-  "name": "SANTANDER CONSUMER BANK AS NORGE, SVERIGE FILIAL",
-  "legalName": "SANTANDER CONSUMER BANK AS NORGE, SVERIGE FILIAL",
+  "name": "Santander Consumer Bank AS Norge, Sverige Filial",
+  "legalName": "Santander Consumer Bank AS Norge, Sverige Filial",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.santanderconsumerbankasnorgesverigefilial.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.santanderconsumer.se.ico",
+  "websiteUrl": "https://www.santanderconsumer.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "insurely"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/sbab.json
+++ b/data/account-providers/sbab.json
@@ -10,7 +10,7 @@
   "legalName": "SBAB",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.sbab.com.ico",
+  "icon": "https://icons.duckduckgo.com/ip3/www.sbab.se.ico",
   "websiteUrl": "https://www.sbab.se/",
   "retailWebLoginUrl": "https://secure.sbab.se/logga-in?as=private",
   "commercialWebLoginUrl": "https://secure.sbab.se/logga-in?as=corporate",
@@ -25,6 +25,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "tink"
   ],
   "ownership": [],

--- a/data/account-providers/seb-bank.json
+++ b/data/account-providers/seb-bank.json
@@ -72,6 +72,7 @@
     "enfuce",
     "fintecture",
     "gocardless",
+    "insurely",
     "klarna",
     "lunchflow",
     "neonomics",

--- a/data/account-providers/skandiabanken.json
+++ b/data/account-providers/skandiabanken.json
@@ -10,8 +10,8 @@
   "legalName": "SKANDIABANKEN",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.skandiabanken.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.skandia.se.ico",
+  "websiteUrl": "https://www.skandia.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/sparbanken-syd.json
+++ b/data/account-providers/sparbanken-syd.json
@@ -11,7 +11,7 @@
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.sparbankensyd.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.sparbankensyd.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "tink",

--- a/data/account-providers/svea-bank.json
+++ b/data/account-providers/svea-bank.json
@@ -10,8 +10,8 @@
   "legalName": "SVEA Bank",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.svea-bank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.svea.com.ico",
+  "websiteUrl": "https://www.svea.com/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "zenith"

--- a/data/account-providers/swedbank.json
+++ b/data/account-providers/swedbank.json
@@ -11,7 +11,7 @@
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.swedbank.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.swedbank.se/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "insurely",
     "lunchflow",
     "synci",
     "yapily"

--- a/data/account-providers/ziklo-bank.json
+++ b/data/account-providers/ziklo-bank.json
@@ -1,17 +1,17 @@
 {
-  "id": "volvofinans-bank",
+  "id": "ziklo-bank",
   "type": [
     "account"
   ],
   "bankType": [
     "retail"
   ],
-  "name": "Volvofinans Bank",
-  "legalName": "Volvofinans Bank",
+  "name": "Ziklo Bank",
+  "legalName": "Ziklo Bank AB",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.volvofinans-bank.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.ziklo.com.ico",
+  "websiteUrl": "https://www.ziklo.com/",
   "countryHQ": "SE",
   "countries": [
     "SE"
@@ -19,10 +19,11 @@
   "webApplication": true,
   "mobileApps": [],
   "compliance": [],
-  "developerPortalUrl": null,
+  "developerPortalUrl": "https://developer.ziklo.com/",
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "insurely",
     "tink"
   ],
   "ownership": [],

--- a/data/api-aggregators/insurely.json
+++ b/data/api-aggregators/insurely.json
@@ -1,0 +1,26 @@
+{
+  "id": "insurely",
+  "label": "Insurely",
+  "website": "https://www.insurely.com/",
+  "iconUrl": "https://www.insurely.com/hubfs/Symbol.png",
+  "developerPortalUrl": "https://docs.insurely.com/",
+  "countryHQ": "SE",
+  "verified": false,
+  "description": "Open finance infrastructure provider giving banks, fintechs and AI companies consented access to financial personal data across Europe.",
+  "marketFocus": "Europe",
+  "note": "Live in Europe and the UK.",
+  "marketCoverage": {
+    "live": [
+      "DE",
+      "DK",
+      "EE",
+      "FR",
+      "GB",
+      "IT",
+      "LT",
+      "LV",
+      "SE"
+    ]
+  },
+  "bankCount": 30
+}

--- a/schema.json
+++ b/schema.json
@@ -427,6 +427,7 @@
               "friendlyscore",
               "gocardless",
               "ibanity",
+              "insurely",
               "klarna",
               "klavi",
               "leantech",


### PR DESCRIPTION
Adds [Insurely](https://www.insurely.com/) (Stockholm) as an API aggregator and tags the 30 Swedish institutions it reaches.

Disclosure: I work at Insurely, so this is a self-listing. `verified` is left `false` for you to decide.

## The aggregator

Insurely is an open finance infrastructure provider, giving banks, fintechs and AI companies consented access to financial personal data across Europe. `marketCoverage.live` lists the nine markets it is live in (DE, DK, EE, FR, GB, IT, LT, LV, SE), per the market selector at https://docs.insurely.com/catalog/.

Institution-level tags here cover Sweden, the market whose catalogue is mapped provider by provider. `bankCount: 30` reflects Sweden only rather than implying mapped coverage elsewhere. Same shape as `open-banking-io`, which declares 31 live markets with tagged banks in one.

## The tags

22 of the 30 are reached over PSD2, 8 by other means. Every institution mapped to an existing provider; none needed a new file.

Where a bank had duplicate entries, I tagged the one other aggregators already use rather than the BIC-registry copy. Six were judgment calls worth your eye:

| Institution | Tagged | Over |
|---|---|---|
| SEB | `seb-bank` | `seb-sweden`, 4 × `skandinaviska-enskilda-banken-*` |
| SBAB | `sbab` | `sbab-bank-se`, `sbab-bank-ab-publ-se` |
| Marginalen | `marginalen-bank-bankaktiebolag-se` | `marginalen-bank-bankaktiebolag` — `MARGSESS` is the real BIC |
| Ikano | `ikano-banken-ab-publ` | `ikano-bank-ab-se`; `ikano-bank` is the German entity |
| Ålandsbanken | `alandsbanken-abp-finlandsvensk-filial` | `alandsbanken` (Finnish parent) — the Swedish branch |
| Bank Norwegian | `bank-norwegian-decoupled` | `bank-norwegian-en-filial-av-noba-bank-group-ab-publ` |

The last is the least certain: the file I used is `countryHQ: SE` but carries the Norwegian BIC `NORWNOK1`. Happy to move it.

Note that Swedbank, Nordea, Handelsbanken and Danske are tagged on their **Swedish** files (`swedbank`, `nordea-se`, `handelsbanken-se`, `danske-bank-se`) rather than the group-level ones `tink` uses. That's deliberate, since it is the Swedish institutions being tagged here, and matches `gocardless`/`lunchflow`/`synci`.

## Data corrections

All predate this change; CI validates changed files, so they surfaced here.

- **`websiteUrl` was null on 18** of the tagged files, which fails the provider schema. Filled from each institution's real domain, all verified to resolve. `handelsbanken-se` pointed at the group site rather than the Swedish one.
- **12 icons pointed at non-existent domains** machine-derived from the provider id or name — `www.danskebankse.com`, `www.nordea-se.com`, `www.laensfoersaekringar-bank.com` and similar, all NXDOMAIN returning DuckDuckGo's 404 placeholder. Repointed and verified to return real image data. Länsförsäkringar uses the bank's own favicon, because DuckDuckGo serves an 8-byte stub (a bare PNG header) for that domain.
- **Nine ALL-CAPS registry names title-cased.**
- **BIC added** to Avanza (`AVANSESX`), Handelsbanken SE (`HANDSESS`), Klarna (`KLRNSESS`) and Nordea SE (`NDEASESS`), each corroborated by the registry sibling already in this repo.

Stub entries were corrected in place rather than duplicated, since `scripts/detect-duplicate-providers.js` exists to merge exactly the kind of duplicate a parallel "curated" entry would create.

## Rename

`volvofinans-bank` → `ziklo-bank`. Volvofinans Bank was rebranded Ziklo Bank AB (org nr 556069-0967, https://www.ziklo.com/); its own site footer reads "Volvofinans — en del av Ziklo Bank". Same pattern as the FidBank UK rename in #559. Adds its developer portal at https://developer.ziklo.com/.

## Checks

`validate-file` passes on all 31 changed data files, filename/id is consistent, and `detect-duplicate-providers.js --ci` reports no duplicates across all 57,830 providers.

## Two things you may want to know

`ok-q8-bank` carries `SWEDSESS` (Swedbank's BIC) and `morrow-bank` carries `NDEASESS` (Nordea's). Both companies check out independently — Morrow Bank moved to a Swedish banking licence on 2 Jan 2026 — but the BICs look wrong. Left alone as out of scope.

Separately: `.github/workflows/validate-data.yml` detects changed files with the pathspec `data/account-providers/**/*.json`. Since every data file is flat in that directory, git matches nothing — replaying it against #573 and #587 returns 0 files in both cases, so the validation steps skip and the job passes unconditionally. Worth an issue rather than a drive-by fix: enabling it would fail on the ~79% of providers that currently don't validate.

