### PR TITLE
Correct Fiskil profile: category, scope and market coverage

### DIFF
--- a/data/api-aggregators/fiskil.json
+++ b/data/api-aggregators/fiskil.json
@@ -5,16 +5,16 @@
   "iconUrl": "https://fiskil.com/favicon.ico",
   "developerPortalUrl": "https://docs.fiskil.com/",
   "institutionStatusUrl": "https://www.fiskil.com/institution-status",
-  "twitter": "fiskilhq",
+  "twitter": null,
   "countryHQ": "AU",
   "marketFocus": "Australia and New Zealand",
   "verified": false,
-  "description": "Open finance platform providing secure access to financial data across Australia and New Zealand",
+  "description": "Open data infrastructure platform providing open banking, open finance and energy-data connectivity across Australia and New Zealand. Provides API access to banks, non-bank lenders and energy providers, plus a managed Data Provider platform for institutions sharing data out.",
   "marketCoverage": {
     "live": ["AU", "NZ"]
   },
   "bankCount": 121,
-  "lastUpdated": "2026-06-27T04:56:50Z",
+  "lastUpdated": "2026-08-20T00:00:00Z",
   "coverage": {
     "byCountry": {
       "AU": 116,


### PR DESCRIPTION
Updates the Fiskil aggregator entry so it matches what the platform actually does. Disclosure: I work at Fiskil, so I have kept this to verifiable corrections.

### Changes

**`description`** — Fiskil is open data infrastructure spanning open banking, open finance and energy data across Australia and New Zealand, and covers non-bank lenders (entering Australia's CDR through staged commencement from 13 July 2026) as well as banks. The previous one-line description covered only financial data, and omitted energy, non-bank lenders, and the Data Provider side of the platform.

**`twitter`** — set to `null`. The handle no longer points to a maintained company account.

**`lastUpdated`** — refreshed.

### Deliberately unchanged

`bankCount` and `coverage` are left as they are. Institution status is published live at <https://www.fiskil.com/institution-status> if it is useful for verification.

### Validation

`node scripts/validate-file.js data/api-aggregators/fiskil.json` → **valid**.

`node scripts/validate-aggregators.js` reports 5 invalid files, all pre-existing and unrelated: `lastUpdated` date-time format errors in `finverse.json`, `pluggy.json`, `powens.json` and two others. `fiskil.json` passes.