### PR TITLE
Create catego.json

### DIFF
--- a/data/api-aggregators/catego.json
+++ b/data/api-aggregators/catego.json
@@ -1,0 +1,29 @@
+{
+  "id": "catego",
+  "label": "Catego",
+  "website": "https://catego.app/",
+  "iconUrl": "https://catego.app/apple-touch-icon.png",
+  "developerPortalUrl": "https://ais.catego.app/api/v1/docs#/",
+  "countryHQ": "LV",
+  "description": "AIS provider and transaction categorization",
+  "statusUrl": "https://status.catego.app",
+  "marketFocus": "Baltics (Latvia, Lithuania, Estonia) and Northern Europe",
+  "marketCoverage": {
+    "live": [
+    "LV",
+    "LT",
+    "EE"
+    ],
+    "upcoming": [
+    "FI",
+    "SE",
+    "NO",
+    "IS",
+    "DK",
+    "NL",
+    "DE",
+    "RO",
+    "PL"
+]
+  }
+}


### PR DESCRIPTION
### Summary
This PR adds **SIA Catego** to the Open Banking Tracker database under the Latvia Hub. 

### Details
* **Entity:** SIA Catego
* **Type:** API Aggregator / AISP
* **License:** 27-55/2026/2 (Latvijas Banka)
* **Core Coverage:** Baltic States (LV, LT, EE)
* **Passported Submarkets:** FI, SE, NO, IS, DK, NL, DE, RO, PL

### Official Verification Links
* Proof of regulatory licensing status can be verified on the official supervisor portal: [Latvijas Banka Financial Market Participant Register](https://www.bank.lv/finansu-tirgus-dalibnieku-registrs/tirgus-dalibnieki/catego-sia)