### PR TITLE
Adding Catego (also added to data/account-providers)

### DIFF
--- a/data/account-providers/artea-bankas-lt.json
+++ b/data/account-providers/artea-bankas-lt.json
@@ -70,7 +70,8 @@
   "apiAggregators": [
     "nordigen",
     "enablebanking",
-    "salt-edge"
+    "salt-edge",
+    "catego"
   ],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/citadele-lv.json
+++ b/data/account-providers/citadele-lv.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/coop-pank.json
+++ b/data/account-providers/coop-pank.json
@@ -27,7 +27,8 @@
     "lunchflow",
     "synci",
     "tink",
-    "volt"
+    "volt",
+    "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/lhv.json
+++ b/data/account-providers/lhv.json
@@ -26,7 +26,8 @@
     "gocardless",
     "lunchflow",
     "synci",
-    "tink"
+    "tink",
+    "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/luminor-lt.json
+++ b/data/account-providers/luminor-lt.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/luminor-lv.json
+++ b/data/account-providers/luminor-lv.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/paysera-lt.json
+++ b/data/account-providers/paysera-lt.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["catego"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/revolut-lt.json
+++ b/data/account-providers/revolut-lt.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/seb-banka.json
+++ b/data/account-providers/seb-banka.json
@@ -24,7 +24,8 @@
   "apiProducts": [],
   "apiAggregators": [
     "volt",
-    "zenith"
+    "zenith",
+    "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/swedbank-ab-lt.json
+++ b/data/account-providers/swedbank-ab-lt.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "zenith"
+    "zenith", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/swedbank-as-ee.json
+++ b/data/account-providers/swedbank-as-ee.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "zenith"
+    "zenith", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/swedbank-as-lv.json
+++ b/data/account-providers/swedbank-as-lv.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "zenith"
+    "zenith", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/wise-lv.json
+++ b/data/account-providers/wise-lv.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-    "plaid"
+    "plaid", "catego"
   ],
   "ownership": [],
   "stateOwned": false,

--- a/schema.json
+++ b/schema.json
@@ -411,6 +411,7 @@
               "bridgeapi-io",
               "bud",
               "budget-insight",
+              "catego",
               "celcoin",
               "enablebanking",
               "enfuce",


### PR DESCRIPTION
### Summary
This PR adds **Catego** to the Open Banking Tracker database under the Latvia Hub. 

### Details
* **Entity:** SIA Catego
* **Type:** API Aggregator / AISP
* **License:** 27-55/2026/2 (Latvijas Banka)
* **Core Coverage:** Baltic States (LV, LT, EE)
* **Passported Submarkets:** FI, SE, NO, IS, DK, NL, DE, RO, PL

### Official Verification Links
* Proof of regulatory licensing status can be verified on the official supervisor portal: [Latvijas Banka Financial Market Participant Register](https://www.bank.lv/en/financial-market-participant-register/market-participants/catego-sia)